### PR TITLE
Created the messageStore as a different file along with all the necessary functions. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+venv/

--- a/src/lib/Input.svelte
+++ b/src/lib/Input.svelte
@@ -9,23 +9,19 @@
 
 <script lang="ts">
     import { createEventDispatcher } from "svelte";
+    import { resetStore } from "./messageStore";
 
     const dispatch = createEventDispatcher<Events>();
 
     let innerText = "";
     let messageReceived = true;
 
-    /**
-     * Removes all white spaces from the innerText.
-     *
-     * @returns {void}
-     */
-    function getRidOfWhiteSpacesInInnerText(): void {
-        innerText = innerText.replace(/\s/g, "");
-    }
+    const getRidOfWhiteSpacesBeforeAndAfter = () => {
+        innerText = innerText.trim();
+    };
 
     const send = () => {
-        getRidOfWhiteSpacesInInnerText();
+        getRidOfWhiteSpacesBeforeAndAfter();
         dispatch("send", {
             message: innerText,
             onResponse: () => (messageReceived = true),
@@ -45,9 +41,20 @@
         innerTextContainsLetters();
 
     const handleKeyDown = (event: KeyboardEvent) => {
-        if (!canSend || event.key !== "Enter" || event.shiftKey) return;
-        send();
-        event.preventDefault();
+        let pressedEnter: boolean = event.key === "Enter";
+        let pressedShift: boolean = event.shiftKey;
+
+        if (pressedEnter) {
+            if (pressedShift) {
+                return;
+            }
+
+            if (canSend) {
+                send();
+            }
+
+            event.preventDefault();
+        }
     };
 </script>
 
@@ -69,7 +76,7 @@
     <button class="send" disabled={!canSend} on:click={send}>
         <span class="material-symbols-outlined">send</span>
     </button>
-    <button class="clear">
+    <button class="clear" on:click={resetStore}>
         <span class="material-symbols-outlined">delete_forever</span>
     </button>
 </div>

--- a/src/lib/Input.svelte
+++ b/src/lib/Input.svelte
@@ -41,18 +41,12 @@
         innerTextContainsLetters();
 
     const handleKeyDown = (event: KeyboardEvent) => {
-        let pressedEnter: boolean = event.key === "Enter";
-        let pressedShift: boolean = event.shiftKey;
+        const pressedEnter: boolean = event.key === "Enter";
+        const pressedShift: boolean = event.shiftKey;
 
         if (pressedEnter) {
-            if (pressedShift) {
-                return;
-            }
-
-            if (canSend) {
-                send();
-            }
-
+            if (pressedShift) return;
+            if (canSend) send();
             event.preventDefault();
         }
     };

--- a/src/lib/MessageContainer.svelte
+++ b/src/lib/MessageContainer.svelte
@@ -9,16 +9,14 @@
         resetStore,
     } from "./messageStore";
 
-    export let messages: MessageType[] = [];
-
     let lastMessage: Message;
     let container: HTMLDivElement;
     let bottom: HTMLDivElement;
 
     const scroll = () => container.scrollTo(0, bottom.offsetTop);
 
-    export const getAll = () => messages;
-    export const getLast = () => messages[messages.length - 1];
+    export const getAll = () => $messageStore;
+    export const getLast = () => $messageStore[$messageStore.length - 1];
 
     export const addMessage = (message: MessageType) => {
         addMessageToStore(message);
@@ -52,7 +50,7 @@
 <div class="container" bind:this={container}>
     {#each $messageStore as { role, content, timestamp }, index}
         {#key index}
-            {#if index === messages.length - 1}
+            {#if index === $messageStore.length - 1}
                 <Message
                     {role}
                     {content}

--- a/src/lib/MessageContainer.svelte
+++ b/src/lib/MessageContainer.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
     import Message from "./Message.svelte";
     import type { Message as MessageType } from "./types";
-    import { onMount } from "svelte";
-
     import {
         messageStore,
         addMessageToStore,
@@ -49,20 +47,10 @@
         // messages = [];
         scroll();
     };
-
-    onMount(() => {
-        // Subscribe to changes in the messageStore
-        const unsubscribe = messageStore.subscribe((data) => {
-            messages = data;
-        });
-
-        // Unsubscribe to avoid memory leaks when the component unmounts
-        return () => unsubscribe();
-    });
 </script>
 
 <div class="container" bind:this={container}>
-    {#each messages as { role, content, timestamp }, index}
+    {#each $messageStore as { role, content, timestamp }, index}
         {#key index}
             {#if index === messages.length - 1}
                 <Message

--- a/src/lib/MessageContainer.svelte
+++ b/src/lib/MessageContainer.svelte
@@ -20,29 +20,22 @@
 
     export const addMessage = (message: MessageType) => {
         addMessageToStore(message);
-        // messages.push(message);
-        // messages = messages;
         scroll();
         return message;
     };
 
     export const updateLastMessageContent = (content: string) => {
         updateLastMsgInStore(content);
-        // messages[messages.length - 1].content = content;
-        // lastMessage?.update(content);
         scroll();
     };
 
     export const appendLastMessageContent = (content: string) => {
         appendContentToLastMsgInStore(content);
-        // getLast().content += content;
-        // lastMessage?.append(content);
         scroll();
     };
 
     export const clearMessages = () => {
         resetStore();
-        // messages = [];
         scroll();
     };
 </script>

--- a/src/lib/MessageContainer.svelte
+++ b/src/lib/MessageContainer.svelte
@@ -1,6 +1,15 @@
 <script lang="ts">
     import Message from "./Message.svelte";
     import type { Message as MessageType } from "./types";
+    import { onMount } from "svelte";
+
+    import {
+        messageStore,
+        addMessageToStore,
+        updateLastMsgInStore,
+        appendContentToLastMsgInStore,
+        resetStore,
+    } from "./messageStore";
 
     export let messages: MessageType[] = [];
 
@@ -14,28 +23,42 @@
     export const getLast = () => messages[messages.length - 1];
 
     export const addMessage = (message: MessageType) => {
-        messages.push(message);
-        messages = messages;
+        addMessageToStore(message);
+        // messages.push(message);
+        // messages = messages;
         scroll();
         return message;
     };
 
     export const updateLastMessageContent = (content: string) => {
-        messages[messages.length - 1].content = content;
-        lastMessage?.update(content);
+        updateLastMsgInStore(content);
+        // messages[messages.length - 1].content = content;
+        // lastMessage?.update(content);
         scroll();
     };
 
     export const appendLastMessageContent = (content: string) => {
-        getLast().content += content;
-        lastMessage?.append(content);
+        appendContentToLastMsgInStore(content);
+        // getLast().content += content;
+        // lastMessage?.append(content);
         scroll();
     };
 
     export const clearMessages = () => {
-        messages = [];
+        resetStore();
+        // messages = [];
         scroll();
     };
+
+    onMount(() => {
+        // Subscribe to changes in the messageStore
+        const unsubscribe = messageStore.subscribe((data) => {
+            messages = data;
+        });
+
+        // Unsubscribe to avoid memory leaks when the component unmounts
+        return () => unsubscribe();
+    });
 </script>
 
 <div class="container" bind:this={container}>

--- a/src/lib/Root.svelte
+++ b/src/lib/Root.svelte
@@ -8,17 +8,33 @@
 
     let opened = false;
     let dragger: Draggable;
+    let messageToUser: string = "Welcome";
 
     const tryToggle = async () => {
         if (dragger.moved()) return;
         opened = !opened;
     };
+
+    const openWindow = async () => {
+        if (dragger.moved()) return;
+        opened = true;
+    };
+
+    const closeWindow = async () => {
+        if (dragger.moved()) return;
+        opened = false;
+        messageToUser = "";
+    };
 </script>
 
 <Draggable bind:this={dragger}>
     {#if opened}
-        <Window initialMessage="Welcome" on:close={tryToggle} {configuration} />
+        <Window
+            initialMessage={messageToUser}
+            on:close={closeWindow}
+            {configuration}
+        />
     {:else}
-        <OpenMe on:click={tryToggle} />
+        <OpenMe on:click={openWindow} />
     {/if}
 </Draggable>

--- a/src/lib/Window.svelte
+++ b/src/lib/Window.svelte
@@ -42,13 +42,14 @@
     };
 
     onMount(() => {
-        if (initialMessage)
+        if (initialMessage) {
             messages.addMessage({
                 sender: "Assistant",
                 role: "assistant",
                 content: initialMessage,
                 timestamp: nowStamp(),
             });
+        }
     });
 </script>
 

--- a/src/lib/Window.svelte
+++ b/src/lib/Window.svelte
@@ -15,7 +15,6 @@
     import { scale } from "svelte/transition";
     import type { Configuration } from "./types";
 
-    export let initialMessage: string;
     export let configuration: Configuration;
 
     const dispatch = createEventDispatcher<Events>();

--- a/src/lib/Window.svelte
+++ b/src/lib/Window.svelte
@@ -40,17 +40,6 @@
 
         event.detail.onResponse();
     };
-
-    onMount(() => {
-        if (initialMessage) {
-            messages.addMessage({
-                sender: "Assistant",
-                role: "assistant",
-                content: initialMessage,
-                timestamp: nowStamp(),
-            });
-        }
-    });
 </script>
 
 <div class="container" in:scale={{ duration: 100 }}>

--- a/src/lib/messageStore.ts
+++ b/src/lib/messageStore.ts
@@ -1,0 +1,36 @@
+import {writable} from "svelte/store";
+import type {Message as MessageType} from "./types";
+import {nowStamp} from ".";
+
+const welcomeMsg = "Welcome";
+
+const initialWelcome: MessageType = {
+    sender: "Assistant",
+    role: "assistant",
+    content: welcomeMsg,
+    timestamp: nowStamp(),
+};
+
+export const messageStore = writable<MessageType[]>([]);
+
+export const addMessageToStore = (message: MessageType) => {
+    messageStore.update((messages) => [...messages, message]);
+};
+
+export const updateLastMsgInStore = (content: string) => {
+    messageStore.update((messages) => {
+        messages[messages.length - 1].content = content;
+        return messages;
+    });
+};
+
+export const appendContentToLastMsgInStore = (content: string) => {
+    messageStore.update((messages) => {
+        messages[messages.length - 1].content += content;
+        return messages;
+    });
+};
+
+export const resetStore = () => {
+    messageStore.set([initialWelcome]);
+};

--- a/src/stories/AddMessage.svelte
+++ b/src/stories/AddMessage.svelte
@@ -22,12 +22,14 @@
                 role: "assistant",
                 content: "Hello, I'm the assistant!",
                 timestamp: new Date().toLocaleTimeString(),
+                sender: "Assistant",
             });
             await untilTimePassed(1000);
             container.addMessage({
                 role: "user",
                 content: "Hello, I'm the user!",
                 timestamp: new Date().toLocaleTimeString(),
+                sender: "Student",
             });
             await untilTimePassed(1000);
             container.updateLastMessageContent(
@@ -36,13 +38,14 @@
             const stack = getParagraphStack();
             while (stack.length > 0) {
                 await untilTimePassed(10);
-                container.appendLastMessageContent(stack.pop());
+                container.appendLastMessageContent(stack.pop()!);
             }
             await untilTimePassed(1000);
             container.addMessage({
                 role: "assistant",
                 content: "Hello, I'm the assistant!",
                 timestamp: new Date().toLocaleTimeString(),
+                sender: "Assistant",
             });
         },
         scroll: async (container) => {
@@ -53,12 +56,13 @@
                 const stack = getParagraphStack();
                 container.addMessage({
                     role: isAssistant ? "assistant" : "user",
-                    content: stack.pop(),
+                    content: stack.pop()!,
                     timestamp: new Date().toLocaleTimeString(),
+                    sender: isAssistant ? "Assistant" : "Student",
                 });
                 while (stack.length > 0) {
                     await untilTimePassed(10);
-                    container.appendLastMessageContent(stack.pop());
+                    container.appendLastMessageContent(stack.pop()!);
                 }
                 messageCount++;
                 isAssistant = !isAssistant;

--- a/src/stories/Message.stories.ts
+++ b/src/stories/Message.stories.ts
@@ -1,19 +1,19 @@
-import type { Meta, StoryObj } from '@storybook/svelte';
+import type {Meta, StoryObj} from '@storybook/svelte';
 import Message from '../lib/Message.svelte';
-import type { Message as MessageType } from '../lib/types';
-import { resetStore } from '../lib/messageStore';
+import type {Message as MessageType} from '../lib/types';
+import {resetStore} from '../lib/messageStore';
 
 const meta = {
     title: "Message",
     component: Message,
     tags: ['autodocs'],
     argTypes: {
-        content: { control: 'text' },
+        content: {control: 'text'},
         role: {
-            control: { type: 'select' },
+            control: {type: 'select'},
             options: ['assistant', 'user'] satisfies MessageType['role'][],
         },
-        timestamp: { control: 'text' },
+        timestamp: {control: 'text'},
     },
     parameters: {
         layout: "fullscreen",
@@ -30,4 +30,4 @@ export const base: Story = {
         content: 'Hello World',
         role: 'assistant',
     },
-}
+};

--- a/src/stories/Message.stories.ts
+++ b/src/stories/Message.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import Message from '../lib/Message.svelte';
 import type { Message as MessageType } from '../lib/types';
+import { resetStore } from '../lib/messageStore';
 
 const meta = {
     title: "Message",
@@ -16,7 +17,8 @@ const meta = {
     },
     parameters: {
         layout: "fullscreen",
-    }
+    },
+    play: resetStore
 } satisfies Meta<Message>;
 
 export default meta;

--- a/src/stories/MessageContainer.stories.ts
+++ b/src/stories/MessageContainer.stories.ts
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from '@storybook/svelte';
 import MessageContainer from '../lib/MessageContainer.svelte';
 import type { Message as MessageType } from '../lib/types';
 import { LoremIpsum } from "lorem-ipsum";
+import { addMessageToStore } from '../lib/messageStore';
+import { nowStamp } from '../lib';
 
 const lorem = new LoremIpsum({
     sentencesPerParagraph: {
@@ -18,11 +20,23 @@ const meta = {
     title: "MessageContainer",
     component: MessageContainer,
     tags: ['autodocs'],
-    argTypes: {
-        messages: { control: 'array' },
-    },
+    argTypes: {},
     parameters: {
         layout: "fullscreen",
+    },
+    play: () => {
+        addMessageToStore({
+            role: 'assistant',
+            content: lorem.generateSentences(1),
+            sender: 'Assistant',
+            timestamp: nowStamp(),
+        });
+        addMessageToStore({
+            role: 'user',
+            content: lorem.generateSentences(1),
+            sender: 'Student',
+            timestamp: nowStamp(),
+        });
     }
 } satisfies Meta<MessageContainer>;
 
@@ -30,20 +44,4 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const base: Story = {
-    args: {
-        messages: [
-            {
-                role: 'assistant',
-                content: lorem.generateSentences(1),
-            },
-            {
-                role: 'user',
-                content: lorem.generateSentences(2),
-            },
-        ] satisfies MessageType[],
-    },
-    play: async (x) => {
-
-    },
-}
+export const base: Story = {}

--- a/src/stories/Root.stories.ts
+++ b/src/stories/Root.stories.ts
@@ -1,11 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import Root from '../lib/Root.svelte';
 import { dummyConfiguration } from './utils';
+import { resetStore } from '../lib/messageStore';
 
 const meta = {
     title: "Root",
     component: Root,
     tags: ['autodocs'],
+    play: resetStore
 } satisfies Meta<Root>;
 
 export default meta;

--- a/src/stories/Window.stories.ts
+++ b/src/stories/Window.stories.ts
@@ -1,6 +1,6 @@
-import type { Meta, StoryObj } from '@storybook/svelte';
+import type {Meta, StoryObj} from '@storybook/svelte';
 import Window from '../lib/Window.svelte';
-import { dummyConfiguration } from './utils';
+import {dummyConfiguration} from './utils';
 
 const meta = {
     title: "Window",
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 export const base: Story = {
     args: {
-        initialMessage: "Welcome to ChatTutor, feel free to ask any questions about this lesson.",
+        // initialMessage: "Welcome to ChatTutor, feel free to ask any questions about this lesson.",
         configuration: dummyConfiguration
     }
-}
+};


### PR DESCRIPTION
Created the file `messageStore.ts` along with all of the regular functions called:

`addMessageToStore (message: MessageType) `

`updateLastMsgInStore (content: string)`,

`appendContentToLastMsgInStore (content: string)`,

`resetStore()`

After this may need to clean up `MessageContainer.svelte` file for code that has not been used. 

Fixed bug from the previous feature of the `Shift + Enter` combo where if you were to press `Enter` with nothing typed, it would also create a new line. Now the message box only creates a new line when the user presses `Shift + Enter` together. 

The messageStore should not be persisting chat through the closing and opening of the chatTutor window. Also the 
`trash can` icon where the user can _delete chat history_ has also been implemented. 